### PR TITLE
Convert to use Test Plan

### DIFF
--- a/.buildkite/commands/build-and-test.sh
+++ b/.buildkite/commands/build-and-test.sh
@@ -19,12 +19,5 @@ fi
 echo "--- :hammer_and_wrench: Building for testing"
 bundle exec fastlane build_for_testing
 
-echo "--- Hack to pass token to the xctestrun"
-# TODO: In real life, the env var name, value, and xctestrun path should be
-# parameters read or injected from somewhere
-/usr/libexec/PlistBuddy -c \
-  "add TestPressTests:EnvironmentVariables:BUILDKITE_ANALYTICS_TOKEN string $BUILDKITE_ANALYTICS_TOKEN" \
-  ./DerivedData/Build/Products/TestPress_iphonesimulator15.5-x86_64.xctestrun
-
 echo "--- :microscope: Running unit tests"
 bundle exec fastlane test_without_building

--- a/TestPress.xcodeproj/project.pbxproj
+++ b/TestPress.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		3F5517312861780B002CF097 /* TestPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPressTests.swift; sourceTree = "<group>"; };
 		3F5517372861780B002CF097 /* TestPressUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestPressUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F55173B2861780B002CF097 /* TestPressUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPressUITests.swift; sourceTree = "<group>"; };
+		3F55174D2861DECC002CF097 /* TestPress.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPress.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				3F5517312861780B002CF097 /* TestPressTests.swift */,
+				3F55174D2861DECC002CF097 /* TestPress.xctestplan */,
 			);
 			path = TestPressTests;
 			sourceTree = "<group>";

--- a/TestPress.xcodeproj/xcshareddata/xcschemes/TestPress.xcscheme
+++ b/TestPress.xcodeproj/xcshareddata/xcschemes/TestPress.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1340"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -36,6 +36,12 @@
             ReferencedContainer = "container:TestPress.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:TestPressTests/TestPress.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "AE4C3283-B800-48AA-9952-6ADE39BB0A01",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:TestPress.xcodeproj",
+      "identifier" : "3F55172C2861780B002CF097",
+      "name" : "TestPressTests"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:TestPress.xcodeproj",
+        "identifier" : "3F55172C2861780B002CF097",
+        "name" : "TestPressTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,9 @@ platform :ios do
 
   lane :test_without_building do
     # TODO: This should be computed, not hardcoded
-    xctestrun_path = File.join(DERIVED_DATA_PATH, 'Build/Products/TestPress_iphonesimulator15.5-x86_64.xctestrun')
+    xctestrun_path = File.join(DERIVED_DATA_PATH, 'Build/Products/TestPress_TestPress_iphonesimulator15.5-x86_64.xctestrun')
+
+    add_buildkite_analytics_token(xctestrun_path: xctestrun_path)
 
     run_tests(
       project: 'TestPress.xcodeproj',
@@ -27,5 +29,20 @@ platform :ios do
       test_without_building: true,
       xctestrun: xctestrun_path
     )
+  end
+
+  def add_buildkite_analytics_token(xctestrun_path:)
+    token_key = 'BUILDKITE_ANALYTICS_TOKEN'
+    token = ENV[token_key]
+    return if token.nil?
+
+    xctestrun = Plist.parse_xml(xctestrun_path)
+    xctestrun['TestConfigurations'].each do |configuration|
+      configuration['TestTargets'].each do |target|
+        target['EnvironmentVariables'][token_key] = token
+      end
+    end
+
+    File.write(xctestrun_path, Plist::Emit.dump(xctestrun))
   end
 end


### PR DESCRIPTION
Notice the change required to inject the `BUILDKITE_ANALYTICS_TOKEN` in the `xctestrun` because it has a different format when using a Test Plan.

<img width="360" alt="image" src="https://user-images.githubusercontent.com/1218433/174794888-a8da8443-97d7-4605-8d69-c3a33f58bd89.png">

👍 