### PR TITLE
Inject `BUILDKITE_ANALYTICS_TOKEN` via Test Plan settings instead of editing `xctestrun`

### DIFF
--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -10,6 +10,12 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "environmentVariableEntries" : [
+      {
+        "key" : "BUILDKITE_ANALYTICS_TOKEN",
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+      }
+    ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:TestPress.xcodeproj",
       "identifier" : "3F55172C2861780B002CF097",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,6 @@ platform :ios do
     # TODO: This should be computed, not hardcoded
     xctestrun_path = File.join(DERIVED_DATA_PATH, 'Build/Products/TestPress_TestPress_iphonesimulator15.5-x86_64.xctestrun')
 
-    add_buildkite_analytics_token(xctestrun_path: xctestrun_path)
-
     run_tests(
       project: 'TestPress.xcodeproj',
       scheme: 'TestPress',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,19 +28,4 @@ platform :ios do
       xctestrun: xctestrun_path
     )
   end
-
-  def add_buildkite_analytics_token(xctestrun_path:)
-    token_key = 'BUILDKITE_ANALYTICS_TOKEN'
-    token = ENV[token_key]
-    return if token.nil?
-
-    xctestrun = Plist.parse_xml(xctestrun_path)
-    xctestrun['TestConfigurations'].each do |configuration|
-      configuration['TestTargets'].each do |target|
-        target['EnvironmentVariables'][token_key] = token
-      end
-    end
-
-    File.write(xctestrun_path, Plist::Emit.dump(xctestrun))
-  end
 end


### PR DESCRIPTION
Kudos @iampatbrown, [see details here](https://github.com/buildkite/test-collector-swift/issues/23#issuecomment-1166800254).

This would be a much better approach than my original `xctestrun` editing before running the tests in CI. 

---

Update: This ~~would be~~ _is_ a much better approach than my original `xctestrun` editing before running the tests in CI. 

![image](https://user-images.githubusercontent.com/1218433/176089318-e10b8f1f-b475-49ce-8698-1993913483fd.png)

<img width="1790" alt="Screen Shot 2022-06-28 at 2 01 24 pm" src="https://user-images.githubusercontent.com/1218433/176089347-7a0bc445-9fe9-4b96-b678-4f30979baefe.png">

_Notice the timestamps_ 😉 