### PR TITLE
Add all Buildkite Test Analytics env var to the Test Plan

### DIFF
--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -14,6 +14,34 @@
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
         "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+      },
+      {
+        "key" : "BUILDKITE_BRANCH",
+        "value" : "$(BUILDKITE_BRANCH)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_ID",
+        "value" : "$(BUILDKITE_BUILD_ID)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_NUMBER",
+        "value" : "$(BUILDKITE_BUILD_NUMBER)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_URL",
+        "value" : "$(BUILDKITE_BUILD_URL)"
+      },
+      {
+        "key" : "BUILDKITE_COMMIT",
+        "value" : "$(BUILDKITE_COMMIT)"
+      },
+      {
+        "key" : "BUILDKITE_JOB_ID",
+        "value" : "$(BUILDKITE_JOB_ID)"
+      },
+      {
+        "key" : "BUILDKITE_MESSAGE",
+        "value" : "$(BUILDKITE_MESSAGE)"
       }
     ],
     "targetForVariableExpansion" : {


### PR DESCRIPTION
I assume this is what we need to get richer information in the Test Analytics interface, like branch name and build backlinks, etc.

See https://buildkite.com/docs/test-analytics/ci-environments#buildkite.

![ttt](https://user-images.githubusercontent.com/1218433/176092154-a69100c7-2924-4e21-a54e-92e211859abb.jpg)

