### PR TITLE
Forward more env vars to the test runner

### DIFF
--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -20,26 +20,6 @@
         "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
       },
       {
-        "key" : "BUILDKITE_ANALYTICS_BRANCH",
-        "value" : "$(BUILDKITE_ANALYTICS_BRANCH)"
-      },
-      {
-        "key" : "BUILDKITE_ANALYTICS_JOB_ID",
-        "value" : "$(BUILDKITE_ANALYTICS_JOB_ID)"
-      },
-      {
-        "key" : "BUILDKITE_ANALYTICS_NUMBER",
-        "value" : "$(BUILDKITE_ANALYTICS_NUMBER)"
-      },
-      {
-        "key" : "BUILDKITE_ANALYTICS_SHA",
-        "value" : "$(BUILDKITE_ANALYTICS_SHA)"
-      },
-      {
-        "key" : "BUILDKITE_ANALYTICS_URL",
-        "value" : "$(BUILDKITE_ANALYTICS_URL)"
-      },
-      {
         "key" : "BUILDKITE_BRANCH",
         "value" : "$(BUILDKITE_BRANCH)"
       },

--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -16,6 +16,26 @@
         "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
       },
       {
+        "key" : "BUILDKITE_ANALYTICS_BRANCH",
+        "value" : "$(BUILDKITE_ANALYTICS_BRANCH)"
+      },
+      {
+        "key" : "BUILDKITE_ANALYTICS_JOB_ID",
+        "value" : "$(BUILDKITE_ANALYTICS_JOB_ID)"
+      },
+      {
+        "key" : "BUILDKITE_ANALYTICS_NUMBER",
+        "value" : "$(BUILDKITE_ANALYTICS_NUMBER)"
+      },
+      {
+        "key" : "BUILDKITE_ANALYTICS_SHA",
+        "value" : "$(BUILDKITE_ANALYTICS_SHA)"
+      },
+      {
+        "key" : "BUILDKITE_ANALYTICS_URL",
+        "value" : "$(BUILDKITE_ANALYTICS_URL)"
+      },
+      {
         "key" : "BUILDKITE_BRANCH",
         "value" : "$(BUILDKITE_BRANCH)"
       },

--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -12,6 +12,10 @@
     "codeCoverage" : false,
     "environmentVariableEntries" : [
       {
+        "key" : "BUILDKITE_ANALYTICS_DEBUG_ENABLED",
+        "value" : "1"
+      },
+      {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
         "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
       },

--- a/TestPressTests/TestPress.xctestplan
+++ b/TestPressTests/TestPress.xctestplan
@@ -50,8 +50,8 @@
     ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:TestPress.xcodeproj",
-      "identifier" : "3F55172C2861780B002CF097",
-      "name" : "TestPressTests"
+      "identifier" : "3F55171C2861780A002CF097",
+      "name" : "TestPress"
     }
   },
   "testTargets" : [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,8 @@ platform :ios do
       project: 'TestPress.xcodeproj',
       scheme: 'TestPress',
       test_without_building: true,
-      xctestrun: xctestrun_path
+      xctestrun: xctestrun_path,
+      output_style: 'raw'
     )
   end
 end


### PR DESCRIPTION
I picked these up from the test collector source code. See https://github.com/buildkite/test-collector-swift/blob/v0.1.1/Sources/Core/Models/Environment/EnvironmentValues.swift#L40-L46

There is only one exception: The `BUILDKITE_ANANLYTICS_MESSAGE` value because it has a typo. See https://github.com/buildkite/test-collector-swift/pull/24.

